### PR TITLE
24/custom control text field

### DIFF
--- a/CareForMe.xcodeproj/project.pbxproj
+++ b/CareForMe.xcodeproj/project.pbxproj
@@ -51,6 +51,9 @@
 		AACA591F2698A5920090CAF2 /* ColorPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACA591E2698A5920090CAF2 /* ColorPickerView.swift */; };
 		AACAF27026952C08005821B4 /* AppSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACAF26F26952C08005821B4 /* AppSettingsController.swift */; };
 		AACD900A2692A3A0009740EA /* NotificationDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACD90092692A3A0009740EA /* NotificationDetailViewController.swift */; };
+		AAD1150326A78DF60010A9D7 /* StatusTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1150226A78DF60010A9D7 /* StatusTextField.swift */; };
+		AAD1150926A7E05C0010A9D7 /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1150826A7E05C0010A9D7 /* Protocols.swift */; };
+		AAD1150B26A7E0D40010A9D7 /* ExampleConformance.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1150A26A7E0D40010A9D7 /* ExampleConformance.swift */; };
 		AAE262BA2679530500ABC882 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE262B92679530500ABC882 /* AppDelegate.swift */; };
 		AAE262BC2679530500ABC882 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE262BB2679530500ABC882 /* SceneDelegate.swift */; };
 		AAE262BE2679530500ABC882 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE262BD2679530500ABC882 /* MainViewController.swift */; };
@@ -159,6 +162,9 @@
 		AACA591E2698A5920090CAF2 /* ColorPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerView.swift; sourceTree = "<group>"; };
 		AACAF26F26952C08005821B4 /* AppSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsController.swift; sourceTree = "<group>"; };
 		AACD90092692A3A0009740EA /* NotificationDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDetailViewController.swift; sourceTree = "<group>"; };
+		AAD1150226A78DF60010A9D7 /* StatusTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusTextField.swift; sourceTree = "<group>"; };
+		AAD1150826A7E05C0010A9D7 /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; };
+		AAD1150A26A7E0D40010A9D7 /* ExampleConformance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleConformance.swift; sourceTree = "<group>"; };
 		AAE262B62679530500ABC882 /* CareForMe.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CareForMe.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAE262B92679530500ABC882 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AAE262BB2679530500ABC882 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -508,6 +514,32 @@
 			path = Controller;
 			sourceTree = "<group>";
 		};
+		AAD1150426A7E02B0010A9D7 /* Custom Controls */ = {
+			isa = PBXGroup;
+			children = (
+				AAD1150C26A7E20C0010A9D7 /* StatusTextField */,
+			);
+			path = "Custom Controls";
+			sourceTree = "<group>";
+		};
+		AAD1150726A7E03C0010A9D7 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				AAD1150826A7E05C0010A9D7 /* Protocols.swift */,
+				AAD1150A26A7E0D40010A9D7 /* ExampleConformance.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		AAD1150C26A7E20C0010A9D7 /* StatusTextField */ = {
+			isa = PBXGroup;
+			children = (
+				AAD1150226A78DF60010A9D7 /* StatusTextField.swift */,
+				AAD1150726A7E03C0010A9D7 /* Model */,
+			);
+			path = StatusTextField;
+			sourceTree = "<group>";
+		};
 		AAE262AD2679530500ABC882 = {
 			isa = PBXGroup;
 			children = (
@@ -565,6 +597,7 @@
 		AAE262F02679715700ABC882 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				AAD1150426A7E02B0010A9D7 /* Custom Controls */,
 				AAE262C42679530600ABC882 /* LaunchScreen.storyboard */,
 				AAE91897268EE160003A8278 /* Extensions */,
 			);
@@ -964,10 +997,12 @@
 				AACAF27026952C08005821B4 /* AppSettingsController.swift in Sources */,
 				AAE918A4268EF9E7003A8278 /* CareNotificationController.swift in Sources */,
 				AAE59FE726975B34008BF7FE /* ParentDetailViewController.swift in Sources */,
+				AAD1150B26A7E0D40010A9D7 /* ExampleConformance.swift in Sources */,
 				AA5068B026918F00006F1126 /* RegistrationVC.swift in Sources */,
 				AA79AD092697FD7200786881 /* ColorWheel.swift in Sources */,
 				AACD900A2692A3A0009740EA /* NotificationDetailViewController.swift in Sources */,
 				AAC9D1812696A86200DB3FA5 /* InstructionView.swift in Sources */,
+				AAD1150926A7E05C0010A9D7 /* Protocols.swift in Sources */,
 				AAE918A2268EF9AA003A8278 /* NotificationListTableView.swift in Sources */,
 				AA6B1978268D9923002B43BA /* CareUser.swift in Sources */,
 				AAE9189B268EF6F6003A8278 /* NotificationListViewController.swift in Sources */,
@@ -984,6 +1019,7 @@
 				AA50685E2690AAA6006F1126 /* TapticFeedback.swift in Sources */,
 				AAC7C8E726A53C820008EFFE /* TargetSelector.swift in Sources */,
 				AAF7C8AB269ABA2500EB11EC /* NeedsModel.swift in Sources */,
+				AAD1150326A78DF60010A9D7 /* StatusTextField.swift in Sources */,
 				AAE262EB2679539800ABC882 /* AlertType.swift in Sources */,
 				AA79AD0B2697FDAF00786881 /* Color.swift in Sources */,
 				AAC9D177269652E200DB3FA5 /* LabeledToggle.swift in Sources */,

--- a/CareForMe.xcodeproj/project.pbxproj
+++ b/CareForMe.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		AAD1150326A78DF60010A9D7 /* StatusTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1150226A78DF60010A9D7 /* StatusTextFieldView.swift */; };
 		AAD1150926A7E05C0010A9D7 /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1150826A7E05C0010A9D7 /* Protocols.swift */; };
 		AAD1150B26A7E0D40010A9D7 /* ExampleConformance.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1150A26A7E0D40010A9D7 /* ExampleConformance.swift */; };
+		AAD468ED26AA6F0100ED9A7E /* EmailStatusTextFieldDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD468EC26AA6F0100ED9A7E /* EmailStatusTextFieldDelegate.swift */; };
 		AAE262BA2679530500ABC882 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE262B92679530500ABC882 /* AppDelegate.swift */; };
 		AAE262BC2679530500ABC882 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE262BB2679530500ABC882 /* SceneDelegate.swift */; };
 		AAE262BE2679530500ABC882 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE262BD2679530500ABC882 /* MainViewController.swift */; };
@@ -169,6 +170,7 @@
 		AAD1150226A78DF60010A9D7 /* StatusTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusTextFieldView.swift; sourceTree = "<group>"; };
 		AAD1150826A7E05C0010A9D7 /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; };
 		AAD1150A26A7E0D40010A9D7 /* ExampleConformance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleConformance.swift; sourceTree = "<group>"; };
+		AAD468EC26AA6F0100ED9A7E /* EmailStatusTextFieldDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailStatusTextFieldDelegate.swift; sourceTree = "<group>"; };
 		AAE262B62679530500ABC882 /* CareForMe.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CareForMe.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAE262B92679530500ABC882 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AAE262BB2679530500ABC882 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -429,6 +431,7 @@
 			isa = PBXGroup;
 			children = (
 				AAC5CCD726A9036800019BE8 /* PasswordStatusTextFieldDelegate.swift */,
+				AAD468EC26AA6F0100ED9A7E /* EmailStatusTextFieldDelegate.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -1043,6 +1046,7 @@
 				AAC12ABB26938C5A0084A1E2 /* RegistrationView.swift in Sources */,
 				AAE262BE2679530500ABC882 /* MainViewController.swift in Sources */,
 				AABF3D33269C0C22008A2CC2 /* AddNeedToCategoryViewControllerView.swift in Sources */,
+				AAD468ED26AA6F0100ED9A7E /* EmailStatusTextFieldDelegate.swift in Sources */,
 				AABF3D26269BBF69008A2CC2 /* AddCategoryViewControllerView.swift in Sources */,
 				AAF7C8A2269A0A8600EB11EC /* StockPhoto.swift in Sources */,
 				AAE262BA2679530500ABC882 /* AppDelegate.swift in Sources */,

--- a/CareForMe.xcodeproj/project.pbxproj
+++ b/CareForMe.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		AAC06D5A2693C7FB00408AE3 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC06D592693C7FB00408AE3 /* LoginView.swift */; };
 		AAC07F49267A497800ADD525 /* UIColor+named.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC07F48267A497800ADD525 /* UIColor+named.swift */; };
 		AAC12ABB26938C5A0084A1E2 /* RegistrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC12ABA26938C5A0084A1E2 /* RegistrationView.swift */; };
+		AAC5CCD526A872B800019BE8 /* StatusTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC5CCD426A872B800019BE8 /* StatusTextField.swift */; };
 		AAC7C8E726A53C820008EFFE /* TargetSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC7C8E626A53C820008EFFE /* TargetSelector.swift */; };
 		AAC9D177269652E200DB3FA5 /* LabeledToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC9D176269652E200DB3FA5 /* LabeledToggle.swift */; };
 		AAC9D17B269656D700DB3FA5 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC9D17A269656D700DB3FA5 /* SettingsViewController.swift */; };
@@ -51,7 +52,7 @@
 		AACA591F2698A5920090CAF2 /* ColorPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACA591E2698A5920090CAF2 /* ColorPickerView.swift */; };
 		AACAF27026952C08005821B4 /* AppSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACAF26F26952C08005821B4 /* AppSettingsController.swift */; };
 		AACD900A2692A3A0009740EA /* NotificationDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACD90092692A3A0009740EA /* NotificationDetailViewController.swift */; };
-		AAD1150326A78DF60010A9D7 /* StatusTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1150226A78DF60010A9D7 /* StatusTextField.swift */; };
+		AAD1150326A78DF60010A9D7 /* StatusTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1150226A78DF60010A9D7 /* StatusTextFieldView.swift */; };
 		AAD1150926A7E05C0010A9D7 /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1150826A7E05C0010A9D7 /* Protocols.swift */; };
 		AAD1150B26A7E0D40010A9D7 /* ExampleConformance.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD1150A26A7E0D40010A9D7 /* ExampleConformance.swift */; };
 		AAE262BA2679530500ABC882 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE262B92679530500ABC882 /* AppDelegate.swift */; };
@@ -153,6 +154,7 @@
 		AAC06D592693C7FB00408AE3 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		AAC07F48267A497800ADD525 /* UIColor+named.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+named.swift"; sourceTree = "<group>"; };
 		AAC12ABA26938C5A0084A1E2 /* RegistrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationView.swift; sourceTree = "<group>"; };
+		AAC5CCD426A872B800019BE8 /* StatusTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusTextField.swift; sourceTree = "<group>"; };
 		AAC7C8E626A53C820008EFFE /* TargetSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetSelector.swift; sourceTree = "<group>"; };
 		AAC9D176269652E200DB3FA5 /* LabeledToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledToggle.swift; sourceTree = "<group>"; };
 		AAC9D17A269656D700DB3FA5 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
@@ -162,7 +164,7 @@
 		AACA591E2698A5920090CAF2 /* ColorPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerView.swift; sourceTree = "<group>"; };
 		AACAF26F26952C08005821B4 /* AppSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsController.swift; sourceTree = "<group>"; };
 		AACD90092692A3A0009740EA /* NotificationDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDetailViewController.swift; sourceTree = "<group>"; };
-		AAD1150226A78DF60010A9D7 /* StatusTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusTextField.swift; sourceTree = "<group>"; };
+		AAD1150226A78DF60010A9D7 /* StatusTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusTextFieldView.swift; sourceTree = "<group>"; };
 		AAD1150826A7E05C0010A9D7 /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; };
 		AAD1150A26A7E0D40010A9D7 /* ExampleConformance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleConformance.swift; sourceTree = "<group>"; };
 		AAE262B62679530500ABC882 /* CareForMe.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CareForMe.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -527,6 +529,7 @@
 			children = (
 				AAD1150826A7E05C0010A9D7 /* Protocols.swift */,
 				AAD1150A26A7E0D40010A9D7 /* ExampleConformance.swift */,
+				AAC5CCD426A872B800019BE8 /* StatusTextField.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -534,7 +537,7 @@
 		AAD1150C26A7E20C0010A9D7 /* StatusTextField */ = {
 			isa = PBXGroup;
 			children = (
-				AAD1150226A78DF60010A9D7 /* StatusTextField.swift */,
+				AAD1150226A78DF60010A9D7 /* StatusTextFieldView.swift */,
 				AAD1150726A7E03C0010A9D7 /* Model */,
 			);
 			path = StatusTextField;
@@ -1019,7 +1022,7 @@
 				AA50685E2690AAA6006F1126 /* TapticFeedback.swift in Sources */,
 				AAC7C8E726A53C820008EFFE /* TargetSelector.swift in Sources */,
 				AAF7C8AB269ABA2500EB11EC /* NeedsModel.swift in Sources */,
-				AAD1150326A78DF60010A9D7 /* StatusTextField.swift in Sources */,
+				AAD1150326A78DF60010A9D7 /* StatusTextFieldView.swift in Sources */,
 				AAE262EB2679539800ABC882 /* AlertType.swift in Sources */,
 				AA79AD0B2697FDAF00786881 /* Color.swift in Sources */,
 				AAC9D177269652E200DB3FA5 /* LabeledToggle.swift in Sources */,
@@ -1031,6 +1034,7 @@
 				AABF3D26269BBF69008A2CC2 /* AddCategoryViewControllerView.swift in Sources */,
 				AAF7C8A2269A0A8600EB11EC /* StockPhoto.swift in Sources */,
 				AAE262BA2679530500ABC882 /* AppDelegate.swift in Sources */,
+				AAC5CCD526A872B800019BE8 /* StatusTextField.swift in Sources */,
 				AABB53E2268FC0E900EF7ABC /* UILabel+preferredFont(for style, weight).swift in Sources */,
 				AAE262F22679716500ABC882 /* CareCollectionView.swift in Sources */,
 				AABF3D2A269BC021008A2CC2 /* UIStackView+componentView.swift in Sources */,

--- a/CareForMe.xcodeproj/project.pbxproj
+++ b/CareForMe.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		AAC07F49267A497800ADD525 /* UIColor+named.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC07F48267A497800ADD525 /* UIColor+named.swift */; };
 		AAC12ABB26938C5A0084A1E2 /* RegistrationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC12ABA26938C5A0084A1E2 /* RegistrationView.swift */; };
 		AAC5CCD526A872B800019BE8 /* StatusTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC5CCD426A872B800019BE8 /* StatusTextField.swift */; };
+		AAC5CCD826A9036800019BE8 /* PasswordStatusTextFieldDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC5CCD726A9036800019BE8 /* PasswordStatusTextFieldDelegate.swift */; };
 		AAC7C8E726A53C820008EFFE /* TargetSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC7C8E626A53C820008EFFE /* TargetSelector.swift */; };
 		AAC9D177269652E200DB3FA5 /* LabeledToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC9D176269652E200DB3FA5 /* LabeledToggle.swift */; };
 		AAC9D17B269656D700DB3FA5 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC9D17A269656D700DB3FA5 /* SettingsViewController.swift */; };
@@ -155,6 +156,7 @@
 		AAC07F48267A497800ADD525 /* UIColor+named.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+named.swift"; sourceTree = "<group>"; };
 		AAC12ABA26938C5A0084A1E2 /* RegistrationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationView.swift; sourceTree = "<group>"; };
 		AAC5CCD426A872B800019BE8 /* StatusTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusTextField.swift; sourceTree = "<group>"; };
+		AAC5CCD726A9036800019BE8 /* PasswordStatusTextFieldDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordStatusTextFieldDelegate.swift; sourceTree = "<group>"; };
 		AAC7C8E626A53C820008EFFE /* TargetSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetSelector.swift; sourceTree = "<group>"; };
 		AAC9D176269652E200DB3FA5 /* LabeledToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledToggle.swift; sourceTree = "<group>"; };
 		AAC9D17A269656D700DB3FA5 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
@@ -423,6 +425,14 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		AAC5CCD626A9035300019BE8 /* Controller */ = {
+			isa = PBXGroup;
+			children = (
+				AAC5CCD726A9036800019BE8 /* PasswordStatusTextFieldDelegate.swift */,
+			);
+			path = Controller;
+			sourceTree = "<group>";
+		};
 		AAC9D174269652C100DB3FA5 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -537,6 +547,7 @@
 		AAD1150C26A7E20C0010A9D7 /* StatusTextField */ = {
 			isa = PBXGroup;
 			children = (
+				AAC5CCD626A9035300019BE8 /* Controller */,
 				AAD1150226A78DF60010A9D7 /* StatusTextFieldView.swift */,
 				AAD1150726A7E03C0010A9D7 /* Model */,
 			);
@@ -1019,6 +1030,7 @@
 				AAE918A6268EFBC3003A8278 /* CareNotificationTableViewCell.swift in Sources */,
 				AA79AD072697FD2F00786881 /* ColorPicker.swift in Sources */,
 				AAF7C8A9269AB91E00EB11EC /* NeedsController.swift in Sources */,
+				AAC5CCD826A9036800019BE8 /* PasswordStatusTextFieldDelegate.swift in Sources */,
 				AA50685E2690AAA6006F1126 /* TapticFeedback.swift in Sources */,
 				AAC7C8E726A53C820008EFFE /* TargetSelector.swift in Sources */,
 				AAF7C8AB269ABA2500EB11EC /* NeedsModel.swift in Sources */,

--- a/CareForMe.xcodeproj/xcuserdata/kennethdubroff.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/CareForMe.xcodeproj/xcuserdata/kennethdubroff.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Care For Me Notifications.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>5</integer>
+			<integer>14</integer>
 		</dict>
 		<key>CareForMe.xcscheme_^#shared#^_</key>
 		<dict>

--- a/CareForMe/Features/Auth/View/LoginView.swift
+++ b/CareForMe/Features/Auth/View/LoginView.swift
@@ -15,27 +15,27 @@ class LoginView: UIView {
     
     weak var delegate: LoginProcessable?
     
+    let passwordDelegate = PasswordStatusTextFieldDelegate()
+    
     var emailAddress: String? {
         emailAddressTextField.text
     }
     
+    var password: String? {
+        passwordTextField.text
+    }
+    
     private lazy var mainStack: UIStackView = {
-        let stack = UIStackView(arrangedSubviews: [emailAddressStack, registerButton])
+        let stack = UIStackView(arrangedSubviews: [textFieldStack, loginButton])
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.axis = .vertical
-        stack.alignment = .center
+        stack.alignment = .fill
         stack.distribution = .fill
         stack.spacing = 4
         return stack
     }()
         
-    private lazy var emailAddressStack: UIStackView = {
-        let stack = UIStackView(arrangedSubviews: [emailLabel, emailAddressTextField])
-        stack.axis = .vertical
-        stack.distribution = .equalCentering
-        stack.alignment = .center
-        return stack
-    }()
+    private lazy var textFieldStack: UIStackView = .componentStack(elements: [emailLabel, emailAddressTextField, passwordTextField])
     
     private lazy var emailLabel: UILabel = {
         let label = UILabel()
@@ -49,7 +49,9 @@ class LoginView: UIView {
         return textField
     }()
     
-    private lazy var registerButton: UIButton = {
+    private lazy var passwordTextField = StatusTextField<PasswordStatusTextFieldDelegate>(type: .information, exampleText: "Password", instructionText: "Please Enter a Password")
+    
+    private lazy var loginButton: UIButton = {
         let button = UIButton(type: .system)
         button.setTitle("Login", for: .normal)
         button.addTarget(self, action: #selector(updateDelegate), for: .touchUpInside)
@@ -59,20 +61,19 @@ class LoginView: UIView {
     private func subViews() {
         addSubview(mainStack)
         
-        let height: CGFloat = 100
-        
         NSLayoutConstraint.activate([
-            mainStack.topAnchor.constraint(equalTo: safeAreaLayoutGuide.centerYAnchor, constant: -height/2),
+            mainStack.centerYAnchor.constraint(equalTo: safeAreaLayoutGuide.centerYAnchor),
             mainStack.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -40),
-            mainStack.heightAnchor.constraint(equalToConstant: height),
             mainStack.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 40)
         ])
         
     }
     
     @objc private func updateDelegate() {
-        guard let emailAddress = emailAddress else { return }
-        delegate?.processLogin(email: emailAddress, password: "12345678")
+        guard let emailAddress = emailAddress,
+              let password = password
+        else { return }
+        delegate?.processLogin(email: emailAddress, password: password)
     }
     
     init(delegate: LoginProcessable) {
@@ -80,6 +81,8 @@ class LoginView: UIView {
         self.delegate = delegate
         backgroundColor = .systemBackground
         subViews()
+        passwordTextField.statusTextFieldDelegate = passwordDelegate
+        passwordDelegate.textFields.append(passwordTextField)
     }
     
     required init?(coder: NSCoder) {

--- a/CareForMe/Features/Auth/View/LoginView.swift
+++ b/CareForMe/Features/Auth/View/LoginView.swift
@@ -16,7 +16,7 @@ class LoginView: UIView {
     weak var delegate: LoginProcessable?
     
     var passwordDelegate: PasswordStatusTextFieldDelegate?
-    var emailDelegate: Foo?
+    var emailDelegate: EmailStatusTextFieldDelegate?
     
     var emailAddress: String? {
         emailAddressTextField.text
@@ -38,7 +38,7 @@ class LoginView: UIView {
         
     private lazy var textFieldStack: UIStackView = .componentStack(elements: [emailAddressTextField, passwordTextField])
     
-    private lazy var emailAddressTextField = StatusTextField<Foo>(type: .information, exampleText: "Email Address", instructionText: "Please Enter an Email Address")
+    private lazy var emailAddressTextField = StatusTextField<EmailStatusTextFieldDelegate>(type: .information, exampleText: "Email Address", instructionText: "Please Enter an Email Address")
     
     private lazy var passwordTextField = StatusTextField<PasswordStatusTextFieldDelegate>(type: .information, exampleText: "Password", instructionText: "Please Enter a Password")
     
@@ -72,7 +72,7 @@ class LoginView: UIView {
         self.delegate = delegate
         backgroundColor = .systemBackground
         self.passwordDelegate = PasswordStatusTextFieldDelegate(textFields: [passwordTextField])
-        self.emailDelegate = Foo(textFields: [emailAddressTextField])
+        self.emailDelegate = EmailStatusTextFieldDelegate(textFields: [emailAddressTextField])
         subViews()
     }
     

--- a/CareForMe/Features/Auth/View/LoginView.swift
+++ b/CareForMe/Features/Auth/View/LoginView.swift
@@ -16,6 +16,7 @@ class LoginView: UIView {
     weak var delegate: LoginProcessable?
     
     var passwordDelegate: PasswordStatusTextFieldDelegate?
+    var emailDelegate: Foo?
     
     var emailAddress: String? {
         emailAddressTextField.text
@@ -35,19 +36,9 @@ class LoginView: UIView {
         return stack
     }()
         
-    private lazy var textFieldStack: UIStackView = .componentStack(elements: [emailLabel, emailAddressTextField, passwordTextField])
+    private lazy var textFieldStack: UIStackView = .componentStack(elements: [emailAddressTextField, passwordTextField])
     
-    private lazy var emailLabel: UILabel = {
-        let label = UILabel()
-        label.text = "Email Address:"
-        return label
-    }()
-    
-    private lazy var emailAddressTextField: UITextField = {
-        let textField = UITextField()
-        textField.placeholder = "Tap To Enter Email Address"
-        return textField
-    }()
+    private lazy var emailAddressTextField = StatusTextField<Foo>(type: .information, exampleText: "Email Address", instructionText: "Please Enter an Email Address")
     
     private lazy var passwordTextField = StatusTextField<PasswordStatusTextFieldDelegate>(type: .information, exampleText: "Password", instructionText: "Please Enter a Password")
     
@@ -81,6 +72,7 @@ class LoginView: UIView {
         self.delegate = delegate
         backgroundColor = .systemBackground
         self.passwordDelegate = PasswordStatusTextFieldDelegate(textFields: [passwordTextField])
+        self.emailDelegate = Foo(textFields: [emailAddressTextField])
         subViews()
     }
     

--- a/CareForMe/Features/Auth/View/LoginView.swift
+++ b/CareForMe/Features/Auth/View/LoginView.swift
@@ -15,7 +15,7 @@ class LoginView: UIView {
     
     weak var delegate: LoginProcessable?
     
-    let passwordDelegate = PasswordStatusTextFieldDelegate()
+    var passwordDelegate: PasswordStatusTextFieldDelegate?
     
     var emailAddress: String? {
         emailAddressTextField.text
@@ -80,9 +80,8 @@ class LoginView: UIView {
         super.init(frame: .zero)
         self.delegate = delegate
         backgroundColor = .systemBackground
+        self.passwordDelegate = PasswordStatusTextFieldDelegate(textFields: [passwordTextField])
         subViews()
-        passwordTextField.statusTextFieldDelegate = passwordDelegate
-        passwordDelegate.textFields.append(passwordTextField)
     }
     
     required init?(coder: NSCoder) {

--- a/CareForMe/Features/Needs/Add Need/View/AddNeedToCategoryViewControllerView.swift
+++ b/CareForMe/Features/Needs/Add Need/View/AddNeedToCategoryViewControllerView.swift
@@ -22,7 +22,7 @@ class AddNeedToCategoryViewControllerView: UIView {
     var selectedPhoto: NamedPhoto! = .firstAid
     
     lazy var parentStack: UIStackView = {
-        let stack = UIStackView(arrangedSubviews: [titleStack, messageStack, imageLabel, imageStack])
+        let stack = UIStackView(arrangedSubviews: [messageStack, imageLabel, imageStack])
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.axis = .vertical
         stack.distribution = .fillProportionally
@@ -30,6 +30,7 @@ class AddNeedToCategoryViewControllerView: UIView {
         return stack
     }()
     
+//    lazy var filledTitleStack: UIView = StatusTextField(type: .information, exampleText: "Example", textFieldPlaceholderText: "Placeholder", instructionText: "Instructions")
     
     lazy var titleStack: UIStackView = .componentStack(elements: [titleLabel, titleTextField])
     

--- a/CareForMe/View/Custom Controls/StatusTextField/Controller/EmailStatusTextFieldDelegate.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Controller/EmailStatusTextFieldDelegate.swift
@@ -1,0 +1,158 @@
+//
+//  EmailStatusTextFieldDelegate.swift
+//  CareForMe
+//
+//  Created by Kenneth Dubroff on 7/22/21.
+//
+
+import UIKit
+
+final class EmailStatusTextFieldDelegate: NSObject, StatusTextFieldDelegate {
+    
+    typealias Error = PasswordError
+    
+    enum PasswordError: StatusErrorable {
+        case invalidCharacter
+        case missingDot
+        case missingMonkeyTail
+        case dotAsFirst
+        case dotAsLast
+        //fallback for cases such as .. not surrounded by \"\"
+        case regexValidationString
+        
+//        static let quotedChars: String = "\"(),:;<>@[\\]"
+        static let specialChars: String = "!#$%&'*+-/=?^_`{|}~"
+        static let validCharSet: CharacterSet = ["-","0","1","2","3","4","5","6","7","8","9","!","@","#","$","%","^","&","*",".","\""]
+        static var displayValidChars: String { "a-z, A-Z, 0-9, \(specialChars)" }
+        static let monkeyTailChar = "@"
+        static let validRegexString = "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\\\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])"
+        
+        var message: String {
+            switch self {
+            case .invalidCharacter:
+                return "Invalid Character"
+            case .missingDot:
+                return "Missing Domain"
+            case .missingMonkeyTail:
+                return "Missing @"
+            case .dotAsFirst:
+                return "\".\" first"
+            case .dotAsLast:
+                return "\".\" last"
+            case .regexValidationString:
+                return "Unknown Error"
+            }
+        }
+        
+        var instructions: String {
+            
+            switch self {
+            case .invalidCharacter:
+                return "That's an invalid character. Please use \(Self.displayValidChars)"
+            case .missingDot:
+                return "You seem to be missing the domain name and/or extension (ex: gmail.com)"
+            case .missingMonkeyTail:
+                return "You seem to be missing the \"commercial at\" (\"\(Self.monkeyTailChar)\") sign"
+            case .dotAsFirst:
+                return "A dot may not be the first character in an email address"
+            case .dotAsLast:
+                return "A dot may not be the last character in an email address"
+            case .regexValidationString:
+                return "An unknown issue occured when validating your email address. Please ensure it is formatted as: user@domain.com"
+            }
+        }
+    }
+    
+    var textFields: [StatusTextField<EmailStatusTextFieldDelegate>]
+    
+    required init(textFields: [StatusTextField<EmailStatusTextFieldDelegate>]) {
+        self.textFields = textFields
+        super.init()
+        for textField in self.textFields {
+            textField.statusTextFieldDelegate = self
+        }
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.endEditing(false)
+        return true
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        defer { textField.resignFirstResponder() }
+        
+        guard let text = textField.text,
+              let statusTextField = textFieldDictionary[textField] else { return }
+        
+        guard text.last != "." else {
+            statusTextField.displayErrorMessage(for: Error.dotAsLast)
+            TapticEngine.failed.tapUser()
+            return
+        }
+        
+        guard text.contains("@") else {
+            statusTextField.displayErrorMessage(for: Error.missingMonkeyTail)
+            TapticEngine.failed.tapUser()
+            return
+        }
+        
+        guard text.contains(".") else {
+            statusTextField.displayErrorMessage(for: Error.missingDot)
+            TapticEngine.failed.tapUser()
+            return
+        }
+        
+        let range = NSRange(location: 0, length: text.utf16.count)
+        
+        guard let regex = try? NSRegularExpression(pattern: Error.validRegexString),
+              regex.firstMatch(in: text, options: [], range: range) != nil else {
+            statusTextField.displayErrorMessage(for: Error.regexValidationString)
+            TapticEngine.failed.tapUser()
+            return
+        }
+        
+    }
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        
+        var text = textField.text ?? ""
+        
+        
+        guard !string.isEmpty else {
+            guard let statusTextField = textFieldDictionary[textField] else { return true }
+            if string.isBackSpace { // backspace is interpreted as empty String even though it's not
+                text = statusTextField.backSpace() // character will be removed, so remove it before comparing
+            }
+            return isValidEmail(string: text, textField: textField)
+        }
+        
+        return isValidEmail(string: text+string, textField: textField)
+    }
+    
+    @discardableResult func isValidEmail(string: String, textField: UITextField) -> Bool {
+        return processChar(string: string, textField: textField)
+    }
+    // .dotAsLast will need to be validated on return
+    @discardableResult private func processChar(string: String, textField: UITextField) -> Bool {
+        guard let statusTextField = textFieldDictionary[textField] else { return false }
+        
+        guard string.first != "." else {
+            statusTextField.displayErrorMessage(for: Error.dotAsFirst)
+            TapticEngine.failed.tapUser()
+            return false
+        }
+        
+        let comparisonSet = CharacterSet.letters.union(Error.validCharSet)
+        let lowerInputCharSet = CharacterSet(charactersIn: string.lowercased())
+        
+        if !comparisonSet.isSuperset(of: lowerInputCharSet) {
+            statusTextField.displayErrorMessage(for: Error.invalidCharacter)
+            TapticEngine.failed.tapUser()
+            return false
+        } else {
+            statusTextField.displayStatusMessage()
+            return true
+        }
+    }
+    
+}

--- a/CareForMe/View/Custom Controls/StatusTextField/Controller/PasswordStatusTextFieldDelegate.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Controller/PasswordStatusTextFieldDelegate.swift
@@ -1,0 +1,76 @@
+//
+//  PasswordStatusTextFieldDelegate.swift
+//  CareForMe
+//
+//  Created by Kenneth Dubroff on 7/21/21.
+//
+
+import UIKit
+
+final class PasswordStatusTextFieldDelegate: NSObject, StatusTextFieldDelegate {
+    
+    typealias Error = PasswordError
+    
+    enum PasswordError: StatusErrorable {
+        case tooShort
+        case invalidCharacter
+        case missingDigit
+        case missingLowerAlpha
+        case missingUpperAlpha
+        case missingSpecial
+        
+        static var specialChars: String { "!@#$%^&*" }
+        static var validChars: String { "a-z, A-Z, 0-9, \(specialChars)" }
+        
+        var message: String {
+            switch self {
+            case .tooShort:
+                return "Too Short"
+            case .invalidCharacter:
+                return "Invalid Character"
+            case .missingDigit:
+                return "Needs Digit"
+            case .missingLowerAlpha:
+                return "Needs Lowercase Alphanumeric Character"
+            case .missingUpperAlpha:
+                return "Needs Uppercase Alphanumeric Character"
+            case .missingSpecial:
+                return "Needs Special Character"
+            }
+        }
+        
+        var instructions: String {
+            
+            switch self {
+            case .tooShort:
+                return "Your password must be at least 6 characters"
+            case .invalidCharacter:
+                return "Your password contains unknown characters. Please use \(Self.validChars)"
+            case .missingDigit:
+                return "Your password must contain at least 1 digit (0-9)"
+            case .missingLowerAlpha:
+                return "Your password must contain at least 1 Lowercase Alphanumeric Character (a-z)"
+            case .missingUpperAlpha:
+                return "Your password must contain at least 1 Uppercase Alphanumeric Character (A-Z)"
+            case .missingSpecial:
+                return "Your password must include at least 1 special character (\(Self.specialChars)"
+            }
+        }
+    }
+    
+    var textFields: [StatusTextField<PasswordStatusTextFieldDelegate>] = []
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        
+        let customSet: CharacterSet = [" ", "-", "a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x","y","z","0","1","2","3","4","5","6","7","8","9","!","@","#","$","%","^","&","*"]
+        let comparisonSet = CharacterSet.letters.union(customSet)         
+        
+        if !comparisonSet.isSuperset(of: CharacterSet(charactersIn: string)) {
+            textFieldDictionary[textField]?.displayErrorMessage(for: Error.invalidCharacter)
+        } else {
+            textFieldDictionary[textField]?.displayStatusMessage()
+        }
+        return true
+    }
+    
+}

--- a/CareForMe/View/Custom Controls/StatusTextField/Controller/PasswordStatusTextFieldDelegate.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Controller/PasswordStatusTextFieldDelegate.swift
@@ -19,8 +19,10 @@ final class PasswordStatusTextFieldDelegate: NSObject, StatusTextFieldDelegate {
         case missingUpperAlpha
         case missingSpecial
         
-        static var specialChars: String { "!@#$%^&*" }
-        static var validChars: String { "a-z, A-Z, 0-9, \(specialChars)" }
+        static let minLength: Int = 6
+        static let specialChars: String = "!@#$%^&*"
+        static let validCharSet: CharacterSet = ["-","0","1","2","3","4","5","6","7","8","9","!","@","#","$","%","^","&","*"]
+        static var displayValidChars: String { "a-z, A-Z, 0-9, \(specialChars)" }
         
         var message: String {
             switch self {
@@ -43,9 +45,9 @@ final class PasswordStatusTextFieldDelegate: NSObject, StatusTextFieldDelegate {
             
             switch self {
             case .tooShort:
-                return "Your password must be at least 6 characters"
+                return "Your password must be at least \(Self.minLength) characters"
             case .invalidCharacter:
-                return "Your password contains unknown characters. Please use \(Self.validChars)"
+                return "That's an invalid character. Please use \(Self.displayValidChars)"
             case .missingDigit:
                 return "Your password must contain at least 1 digit (0-9)"
             case .missingLowerAlpha:
@@ -53,7 +55,7 @@ final class PasswordStatusTextFieldDelegate: NSObject, StatusTextFieldDelegate {
             case .missingUpperAlpha:
                 return "Your password must contain at least 1 Uppercase Alphanumeric Character (A-Z)"
             case .missingSpecial:
-                return "Your password must include at least 1 special character (\(Self.specialChars)"
+                return "Your password must include at least 1 special character (\(Self.specialChars))"
             }
         }
     }

--- a/CareForMe/View/Custom Controls/StatusTextField/Controller/PasswordStatusTextFieldDelegate.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Controller/PasswordStatusTextFieldDelegate.swift
@@ -70,8 +70,12 @@ final class PasswordStatusTextFieldDelegate: NSObject, StatusTextFieldDelegate {
         }
     }
     
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+    
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        // TODO: Intercept bad password choices? i.e. stop character from being entered
         
         var text = textField.text ?? ""
         

--- a/CareForMe/View/Custom Controls/StatusTextField/Controller/PasswordStatusTextFieldDelegate.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Controller/PasswordStatusTextFieldDelegate.swift
@@ -58,7 +58,15 @@ final class PasswordStatusTextFieldDelegate: NSObject, StatusTextFieldDelegate {
         }
     }
     
-    var textFields: [StatusTextField<PasswordStatusTextFieldDelegate>] = []
+    var textFields: [StatusTextField<PasswordStatusTextFieldDelegate>]
+    
+    required init(textFields: [StatusTextField<PasswordStatusTextFieldDelegate>]) {
+        self.textFields = textFields
+        super.init()
+        for textField in self.textFields {
+            textField.statusTextFieldDelegate = self
+        }
+    }
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         

--- a/CareForMe/View/Custom Controls/StatusTextField/Controller/PasswordStatusTextFieldDelegate.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Controller/PasswordStatusTextFieldDelegate.swift
@@ -78,10 +78,12 @@ final class PasswordStatusTextFieldDelegate: NSObject, StatusTextFieldDelegate {
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         
         var text = textField.text ?? ""
+
+        guard let statusTextField = textFieldDictionary[textField] else { return true }
         
         guard !string.isEmpty else {
             if string.isBackSpace { // backspace is interpreted as empty String even though it's not
-                text.removeLast() // character will be removed, so remove it before comparing
+                text = statusTextField.backSpace() // character will be removed, so remove it before comparing
             }
             return isValidPassword(string: text, textField: textField)
         }
@@ -90,10 +92,10 @@ final class PasswordStatusTextFieldDelegate: NSObject, StatusTextFieldDelegate {
     }
     
     @discardableResult func isValidPassword(string: String, textField: UITextField) -> Bool {
-        return processChar(string: string, textField: textField)
+        return processChars(string: string, textField: textField)
     }
     
-    @discardableResult private func processChar(string: String, textField: UITextField) -> Bool {
+    @discardableResult private func processChars(string: String, textField: UITextField) -> Bool {
         let comparisonSet = CharacterSet.letters.union(Error.validCharSet)
         let lowerInputCharSet = CharacterSet(charactersIn: string.lowercased())
         

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
@@ -26,16 +26,29 @@ final class ExampleStatusTextFieldPasswordDelegate: UIViewController {
             }
         }
     }
-    lazy var textFields: [StatusTextField<ExampleStatusTextFieldPasswordDelegate>] = [textField]
+    var textFields: [StatusTextField<ExampleStatusTextFieldPasswordDelegate>]
     typealias Error = PasswordError
     
-    lazy var fooController = Foo(statusTextField: textField2)
+    var fooController: Foo?
     
     var textField2: StatusTextField<Foo> = StatusTextField<Foo>(type: .information, exampleText: "Example2", textFieldPlaceholderText: "Test2", instructionText: "Instructions 2")
     
     var textField: StatusTextField = StatusTextField<ExampleStatusTextFieldPasswordDelegate>(type: .information, exampleText: "Example", textFieldPlaceholderText: "Test", instructionText: "Instructions")
     
     lazy var stack: UIStackView = .componentStack(elements: [textField, textField2])
+    
+    required init(textFields: [StatusTextField<ExampleStatusTextFieldPasswordDelegate>]) {
+        self.textFields = [textField]
+        super.init(nibName: nil, bundle: nil)
+        for textField in self.textFields {
+            textField.statusTextFieldDelegate = self
+        }
+        fooController = .init(textFields: [textField2])
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("programmatic view")
+    }
     
     override func loadView() {
         view = stack
@@ -51,7 +64,6 @@ final class ExampleStatusTextFieldPasswordDelegate: UIViewController {
 }
 
 extension ExampleStatusTextFieldPasswordDelegate: StatusTextFieldDelegate {
-    
     
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
@@ -73,6 +85,8 @@ extension ExampleStatusTextFieldPasswordDelegate: StatusTextFieldDelegate {
 // MARK: - Outside Controller -
 final class Foo: NSObject, StatusTextFieldDelegate {
     
+    
+    
     enum FooError: Swift.Error, StatusErrorable {
         case badStuffHappenedHere
         
@@ -82,9 +96,9 @@ final class Foo: NSObject, StatusTextFieldDelegate {
     
     lazy var textFields: [StatusTextField<Foo>] = statusTextField != nil ? [statusTextField!] : []
     
-    required init(statusTextField: StatusTextField<Foo>) {
+    init(textFields: [StatusTextField<Foo>]) {
         super.init()
-        self.statusTextField = statusTextField
+        self.textFields = textFields
     }
     
     weak var statusTextField: StatusTextField<Foo>?

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
@@ -93,12 +93,23 @@ final class Foo: NSObject, StatusTextFieldDelegate {
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         
-        if textField.text?.isEmpty ?? true {
-            textFieldDictionary[textField]?.displayStatusMessage()
-        } else {
+        guard let text = textField.text else { return true }
+        let string = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        let allEmpty = text.isEmpty && string.isEmpty
+        let stringIsBackSpace = text.isEmpty && string == .backSpace
+        let willBecomeEmpty = (text.count == 1 && string == .backSpace) || (text.count == 1 && string.isEmpty)
+        
+        if allEmpty || stringIsBackSpace || willBecomeEmpty {
             textFieldDictionary[textField]?.displayErrorMessage(for: Error.badStuffHappenedHere)
+        } else {
+            textFieldDictionary[textField]?.displayStatusMessage()
         }
         return true
     }
     
+}
+
+extension String {
+    static let backSpace = String(UnicodeScalar(8))
 }

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
@@ -1,0 +1,98 @@
+//
+//  File.swift
+//  CareForMe
+//
+//  Created by Kenneth Dubroff on 7/20/21.
+//
+
+import UIKit
+
+enum PasswordError: StatusErrorable {
+    case invalidPassword
+    
+    var message: String {
+        switch self {
+        case .invalidPassword:
+            return "Invalid Password"
+        }
+    }
+    
+    var instructions: String {
+        switch self {
+        case .invalidPassword:
+            return "Must contain some stuff you didn't put"
+        }
+    }
+}
+// MARK: - ViewController used as Controller -
+final class ExampleStatusTextFieldPasswordDelegate: UIViewController, UITextFieldDelegate {
+    typealias Error = PasswordError
+    
+    let fooController = Foo()
+    
+    var textField2: StatusTextField<Foo> = StatusTextField<Foo>(type: .information, exampleText: "Example2", textFieldPlaceholderText: "Test2", instructionText: "Instructions 2")
+    
+    var textField: StatusTextField = StatusTextField<ExampleStatusTextFieldPasswordDelegate>(type: .information, exampleText: "Example", textFieldPlaceholderText: "Test", instructionText: "Instructions")
+    
+    lazy var stack: UIStackView = .componentStack(elements: [textField, textField2])
+    
+    override func loadView() {
+        view = stack
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        textField2.statusTextFieldDelegate = fooController
+        textField.statusTextFieldDelegate = self
+        view.backgroundColor = .systemBackground
+    }
+    
+    
+    func displayMessage(type: StatusType) {
+        switch type {
+        case let .error(error):
+            textField.displayErrorMessage(for: error)
+        case .information:
+            textField.displayStatusMessage()
+        }
+    }
+    
+}
+
+extension ExampleStatusTextFieldPasswordDelegate: StatusTextFieldDelegate {
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        
+        if textField.text == "Foo" {
+            print("entered super secret testing mode, try an \"!\"")
+            if string == "!" {
+                displayMessage(type: .error(Error.invalidPassword))
+            }
+        } else if textField.text == "Foo!" {
+            displayMessage(type: .information)
+        }
+        return true
+        
+    }
+    
+}
+
+// MARK: - Outside Controller -
+enum FooError: StatusErrorable {
+    var message: String { "bad" }
+    
+    var instructions: String { "bad juju, abort now" }
+    
+    case badStuffHappenedHere
+    
+}
+
+class Foo: NSObject, StatusTextFieldDelegate, UITextFieldDelegate {
+    typealias Error = FooError
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        print("Foo")
+        return true
+    }
+    
+}

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
@@ -25,7 +25,8 @@ enum PasswordError: StatusErrorable {
     }
 }
 // MARK: - ViewController used as Controller -
-final class ExampleStatusTextFieldPasswordDelegate: UIViewController, UITextFieldDelegate {
+final class ExampleStatusTextFieldPasswordDelegate: UIViewController {
+    lazy var textFields: [StatusTextField<ExampleStatusTextFieldPasswordDelegate>] = [textField]
     typealias Error = PasswordError
     
     lazy var fooController = Foo(statusTextField: textField2)
@@ -51,15 +52,18 @@ final class ExampleStatusTextFieldPasswordDelegate: UIViewController, UITextFiel
 
 extension ExampleStatusTextFieldPasswordDelegate: StatusTextFieldDelegate {
     
+    
+    
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        let textFields: [UITextField: StatusTextField] = Dictionary(uniqueKeysWithValues: self.textFields.map { ($0.textFieldView.textField, $0) })
         
         if textField.text == "Foo" {
             print("entered super secret testing mode, try an \"!\"")
             if string == "!" {
-                self.textField.displayErrorMessage(for: Error.invalidPassword)
+                textFields[textField]?.displayErrorMessage(for: Error.invalidPassword)
             }
         } else if textField.text == "Foo!" {
-            self.textField.displayStatusMessage()
+            textFields[textField]?.displayStatusMessage()
         }
         return true
         
@@ -68,16 +72,17 @@ extension ExampleStatusTextFieldPasswordDelegate: StatusTextFieldDelegate {
 }
 
 // MARK: - Outside Controller -
-enum FooError: StatusErrorable {
-    var message: String { "bad" }
+final class Foo: NSObject, StatusTextFieldDelegate {
     
-    var instructions: String { "bad juju, abort now" }
+    enum FooError: StatusErrorable {
+        var message: String { "bad" }
+        
+        var instructions: String { "bad juju, abort now" }
+        
+        case badStuffHappenedHere
+    }
     
-    case badStuffHappenedHere
-    
-}
-
-class Foo: NSObject, StatusTextFieldDelegate, UITextFieldDelegate {
+    lazy var textFields: [StatusTextField<Foo>] = statusTextField != nil ? [statusTextField!] : []
     
     required init(statusTextField: StatusTextField<Foo>) {
         super.init()
@@ -89,10 +94,12 @@ class Foo: NSObject, StatusTextFieldDelegate, UITextFieldDelegate {
     typealias Error = FooError
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        let textFields: [UITextField: StatusTextField] = Dictionary(uniqueKeysWithValues: self.textFields.map { ($0.textFieldView.textField, $0) })
+        
         if textField.text?.isEmpty ?? true {
-            statusTextField?.displayStatusMessage()
+            textFields[textField]?.displayStatusMessage()
         } else {
-            statusTextField?.displayErrorMessage(for: Error.badStuffHappenedHere)
+            textFields[textField]?.displayErrorMessage(for: Error.badStuffHappenedHere)
         }
         return true
     }

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
@@ -28,7 +28,7 @@ enum PasswordError: StatusErrorable {
 final class ExampleStatusTextFieldPasswordDelegate: UIViewController, UITextFieldDelegate {
     typealias Error = PasswordError
     
-    let fooController = Foo()
+    lazy var fooController = Foo(statusTextField: textField2)
     
     var textField2: StatusTextField<Foo> = StatusTextField<Foo>(type: .information, exampleText: "Example2", textFieldPlaceholderText: "Test2", instructionText: "Instructions 2")
     
@@ -47,16 +47,6 @@ final class ExampleStatusTextFieldPasswordDelegate: UIViewController, UITextFiel
         view.backgroundColor = .systemBackground
     }
     
-    
-    func displayMessage(type: StatusType) {
-        switch type {
-        case let .error(error):
-            textField.displayErrorMessage(for: error)
-        case .information:
-            textField.displayStatusMessage()
-        }
-    }
-    
 }
 
 extension ExampleStatusTextFieldPasswordDelegate: StatusTextFieldDelegate {
@@ -66,10 +56,10 @@ extension ExampleStatusTextFieldPasswordDelegate: StatusTextFieldDelegate {
         if textField.text == "Foo" {
             print("entered super secret testing mode, try an \"!\"")
             if string == "!" {
-                displayMessage(type: .error(Error.invalidPassword))
+                self.textField.displayErrorMessage(for: Error.invalidPassword)
             }
         } else if textField.text == "Foo!" {
-            displayMessage(type: .information)
+            self.textField.displayStatusMessage()
         }
         return true
         
@@ -88,10 +78,22 @@ enum FooError: StatusErrorable {
 }
 
 class Foo: NSObject, StatusTextFieldDelegate, UITextFieldDelegate {
+    
+    required init(statusTextField: StatusTextField<Foo>) {
+        super.init()
+        self.statusTextField = statusTextField
+    }
+    
+    weak var statusTextField: StatusTextField<Foo>?
+    
     typealias Error = FooError
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        print("Foo")
+        if textField.text?.isEmpty ?? true {
+            statusTextField?.displayStatusMessage()
+        } else {
+            statusTextField?.displayErrorMessage(for: Error.badStuffHappenedHere)
+        }
         return true
     }
     

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
@@ -55,15 +55,14 @@ extension ExampleStatusTextFieldPasswordDelegate: StatusTextFieldDelegate {
     
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        let textFields: [UITextField: StatusTextField] = Dictionary(uniqueKeysWithValues: self.textFields.map { ($0.textFieldView.textField, $0) })
         
         if textField.text == "Foo" {
             print("entered super secret testing mode, try an \"!\"")
             if string == "!" {
-                textFields[textField]?.displayErrorMessage(for: Error.invalidPassword)
+                textFieldDictionary[textField]?.displayErrorMessage(for: Error.invalidPassword)
             }
         } else if textField.text == "Foo!" {
-            textFields[textField]?.displayStatusMessage()
+            textFieldDictionary[textField]?.displayStatusMessage()
         }
         return true
         
@@ -94,12 +93,11 @@ final class Foo: NSObject, StatusTextFieldDelegate {
     typealias Error = FooError
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        let textFields: [UITextField: StatusTextField] = Dictionary(uniqueKeysWithValues: self.textFields.map { ($0.textFieldView.textField, $0) })
         
         if textField.text?.isEmpty ?? true {
-            textFields[textField]?.displayStatusMessage()
+            textFieldDictionary[textField]?.displayStatusMessage()
         } else {
-            textFields[textField]?.displayErrorMessage(for: Error.badStuffHappenedHere)
+            textFieldDictionary[textField]?.displayErrorMessage(for: Error.badStuffHappenedHere)
         }
         return true
     }

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
@@ -62,7 +62,10 @@ final class ExampleStatusTextFieldPasswordDelegate: UIViewController {
 }
 
 extension ExampleStatusTextFieldPasswordDelegate: StatusTextFieldDelegate {
-    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         
@@ -105,6 +108,11 @@ final class Foo: NSObject, StatusTextFieldDelegate {
     weak var statusTextField: StatusTextField<Foo>?
     
     typealias Error = FooError
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
@@ -56,8 +56,6 @@ final class ExampleStatusTextFieldPasswordDelegate: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        textField2.statusTextFieldDelegate = fooController
-        textField.statusTextFieldDelegate = self
         view.backgroundColor = .systemBackground
     }
     
@@ -114,8 +112,8 @@ final class Foo: NSObject, StatusTextFieldDelegate {
         let string = string.trimmingCharacters(in: .whitespacesAndNewlines)
         
         let allEmpty = text.isEmpty && string.isEmpty
-        let stringIsBackSpace = text.isEmpty && string == .backSpace
-        let willBecomeEmpty = (text.count == 1 && string == .backSpace) || (text.count == 1 && string.isEmpty)
+        let stringIsBackSpace = text.isEmpty && string.isBackSpace
+        let willBecomeEmpty = (text.count == 1 && string.isBackSpace) || (text.count == 1 && string.isEmpty)
         
         if allEmpty || stringIsBackSpace || willBecomeEmpty {
             textFieldDictionary[textField]?.displayErrorMessage(for: Error.badStuffHappenedHere)
@@ -125,8 +123,15 @@ final class Foo: NSObject, StatusTextFieldDelegate {
         return true
     }
     
+    
 }
 
 extension String {
-    static let backSpace = String(UnicodeScalar(8))
+    var isBackSpace: Bool {
+        let isBackspace = strcmp(cString(using: .utf8), "\\b")
+        if isBackspace == -92 {
+            return true
+        }
+        return false
+    }
 }

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
@@ -99,6 +99,9 @@ final class Foo: NSObject, StatusTextFieldDelegate {
     init(textFields: [StatusTextField<Foo>]) {
         super.init()
         self.textFields = textFields
+        for textField in textFields {
+            textField.statusTextFieldDelegate = self
+        }
     }
     
     weak var statusTextField: StatusTextField<Foo>?

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/ExampleConformance.swift
@@ -7,25 +7,25 @@
 
 import UIKit
 
-enum PasswordError: StatusErrorable {
-    case invalidPassword
-    
-    var message: String {
-        switch self {
-        case .invalidPassword:
-            return "Invalid Password"
-        }
-    }
-    
-    var instructions: String {
-        switch self {
-        case .invalidPassword:
-            return "Must contain some stuff you didn't put"
-        }
-    }
-}
 // MARK: - ViewController used as Controller -
 final class ExampleStatusTextFieldPasswordDelegate: UIViewController {
+    enum PasswordError: Swift.Error, StatusErrorable {
+        case invalidPassword
+        
+        var message: String {
+            switch self {
+            case .invalidPassword:
+                return "Invalid Password"
+            }
+        }
+        
+        var instructions: String {
+            switch self {
+            case .invalidPassword:
+                return "Must contain some stuff you didn't put"
+            }
+        }
+    }
     lazy var textFields: [StatusTextField<ExampleStatusTextFieldPasswordDelegate>] = [textField]
     typealias Error = PasswordError
     
@@ -73,12 +73,11 @@ extension ExampleStatusTextFieldPasswordDelegate: StatusTextFieldDelegate {
 // MARK: - Outside Controller -
 final class Foo: NSObject, StatusTextFieldDelegate {
     
-    enum FooError: StatusErrorable {
-        var message: String { "bad" }
-        
-        var instructions: String { "bad juju, abort now" }
-        
+    enum FooError: Swift.Error, StatusErrorable {
         case badStuffHappenedHere
+        
+        var message: String { "Empty" }
+        var instructions: String { "This field cannot be empty" }
     }
     
     lazy var textFields: [StatusTextField<Foo>] = statusTextField != nil ? [statusTextField!] : []

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/Protocols.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/Protocols.swift
@@ -18,6 +18,7 @@ protocol StatusTextFieldDelegate: UITextFieldDelegate {
     var textFieldDictionary: [UITextField: StatusTextField<Self>] { get }
     associatedtype Error: StatusErrorable
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool
     init(textFields: [StatusTextField<Self>])
 }
 

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/Protocols.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/Protocols.swift
@@ -1,0 +1,19 @@
+//
+//  Protocols.swift
+//  CareForMe
+//
+//  Created by Kenneth Dubroff on 7/20/21.
+//
+
+import UIKit
+
+protocol StatusErrorable: Error {
+    var message: String { get }
+    var instructions: String { get }
+}
+
+/// Associated Type is used to guarantee class has access to required Error type (`StatusErrorable`)
+protocol StatusTextFieldDelegate: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool
+    associatedtype Error: StatusErrorable
+}

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/Protocols.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/Protocols.swift
@@ -14,6 +14,7 @@ protocol StatusErrorable: Error {
 
 /// Associated Type is used to guarantee class has access to required Error type (`StatusErrorable`)
 protocol StatusTextFieldDelegate: UITextFieldDelegate {
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool
+    var textFields: [StatusTextField<Self>] { get set }
     associatedtype Error: StatusErrorable
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool
 }

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/Protocols.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/Protocols.swift
@@ -15,6 +15,13 @@ protocol StatusErrorable: Error {
 /// Associated Type is used to guarantee class has access to required Error type (`StatusErrorable`)
 protocol StatusTextFieldDelegate: UITextFieldDelegate {
     var textFields: [StatusTextField<Self>] { get set }
+    var textFieldDictionary: [UITextField: StatusTextField<Self>] { get }
     associatedtype Error: StatusErrorable
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool
+}
+
+extension StatusTextFieldDelegate {
+    var textFieldDictionary: [UITextField: StatusTextField<Self>] {
+        Dictionary(uniqueKeysWithValues: self.textFields.map { ($0.textFieldView.textField, $0) })
+    }
 }

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/Protocols.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/Protocols.swift
@@ -18,6 +18,7 @@ protocol StatusTextFieldDelegate: UITextFieldDelegate {
     var textFieldDictionary: [UITextField: StatusTextField<Self>] { get }
     associatedtype Error: StatusErrorable
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool
+    init(textFields: [StatusTextField<Self>])
 }
 
 extension StatusTextFieldDelegate {

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/StatusTextField.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/StatusTextField.swift
@@ -23,6 +23,15 @@ class StatusTextField<T: StatusTextFieldDelegate>: UIControl {
         textFieldView.textField.text
     }
     
+    var error: StatusErrorable? {
+        switch self.type {
+        case .information:
+            return nil
+        case let .error(error):
+            return error
+        }
+    }
+    
     lazy var textFieldView: StatusTextFieldView = StatusTextFieldView(type: type, exampleText: exampleText, textFieldPlaceholderText: textFieldPlaceholderText, instructionText: instructionText)
     
     required init(type: StatusType, exampleText: String? = nil, textFieldPlaceholderText: String? = nil, instructionText: String? = nil) {

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/StatusTextField.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/StatusTextField.swift
@@ -1,0 +1,57 @@
+//
+//  StatusTextField.swift
+//  CareForMe
+//
+//  Created by Kenneth Dubroff on 7/21/21.
+//
+
+import UIKit
+
+class StatusTextField<T: StatusTextFieldDelegate>: UIControl {
+    
+    weak var statusTextFieldDelegate: T? {
+        didSet {
+            textFieldView.delegate = statusTextFieldDelegate
+        }
+    }
+    var type: StatusType
+    var exampleText: String?
+    var textFieldPlaceholderText: String?
+    var instructionText: String?
+    
+    lazy var textFieldView: StatusTextFieldView = StatusTextFieldView(type: type, exampleText: exampleText, textFieldPlaceholderText: textFieldPlaceholderText, instructionText: instructionText)
+    
+    internal init(type: StatusType, exampleText: String? = nil, textFieldPlaceholderText: String? = nil, instructionText: String? = nil) {
+        self.type = type
+        self.exampleText = exampleText
+        self.textFieldPlaceholderText = textFieldPlaceholderText
+        self.instructionText = instructionText
+        super.init(frame: .zero)
+        textFieldView.delegate = statusTextFieldDelegate
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("programmatic view")
+    }
+    
+    private func setupViews() {
+        addSubview(textFieldView)
+        textFieldView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            textFieldView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            textFieldView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
+            textFieldView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+            textFieldView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor)
+        ])
+    }
+    
+    func displayErrorMessage(for error: StatusErrorable) {
+        self.textFieldView.displayErrorMessage(for: error)
+    }
+    
+    func displayStatusMessage() {
+        self.textFieldView.displayStatusMessage()
+    }
+    
+}

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/StatusTextField.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/StatusTextField.swift
@@ -14,10 +14,14 @@ class StatusTextField<T: StatusTextFieldDelegate>: UIControl {
             textFieldView.delegate = statusTextFieldDelegate
         }
     }
-    var type: StatusType
-    var exampleText: String?
-    var textFieldPlaceholderText: String?
-    var instructionText: String?
+    private var type: StatusType
+    private var exampleText: String?
+    private var textFieldPlaceholderText: String?
+    private var instructionText: String?
+    
+    var text: String? {
+        textFieldView.textField.text
+    }
     
     lazy var textFieldView: StatusTextFieldView = StatusTextFieldView(type: type, exampleText: exampleText, textFieldPlaceholderText: textFieldPlaceholderText, instructionText: instructionText)
     

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/StatusTextField.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/StatusTextField.swift
@@ -67,4 +67,19 @@ class StatusTextField<T: StatusTextFieldDelegate>: UIControl {
         self.textFieldView.displayStatusMessage()
     }
     
+    /// removes a character from 1 position behind the cursor and returns the result
+    func backSpace() -> String {
+        let textField = textFieldView.textField
+        guard var text = text,
+              let selectedRange = textField.selectedTextRange,
+              !text.isEmpty
+        else { return "" }
+        
+        let offset = textField.offset(from: textField.beginningOfDocument, to: selectedRange.start)
+        
+        let index = text.index(text.startIndex, offsetBy: offset-1)
+        text.remove(at: index)
+        return text
+    }
+    
 }

--- a/CareForMe/View/Custom Controls/StatusTextField/Model/StatusTextField.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/Model/StatusTextField.swift
@@ -25,7 +25,7 @@ class StatusTextField<T: StatusTextFieldDelegate>: UIControl {
     
     lazy var textFieldView: StatusTextFieldView = StatusTextFieldView(type: type, exampleText: exampleText, textFieldPlaceholderText: textFieldPlaceholderText, instructionText: instructionText)
     
-    internal init(type: StatusType, exampleText: String? = nil, textFieldPlaceholderText: String? = nil, instructionText: String? = nil) {
+    required init(type: StatusType, exampleText: String? = nil, textFieldPlaceholderText: String? = nil, instructionText: String? = nil) {
         self.type = type
         self.exampleText = exampleText
         self.textFieldPlaceholderText = textFieldPlaceholderText

--- a/CareForMe/View/Custom Controls/StatusTextField/StatusTextField.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/StatusTextField.swift
@@ -1,0 +1,142 @@
+//
+//  StatusTextField.swift
+//  CareForMe
+//
+//  Created by Kenneth Dubroff on 7/20/21.
+//
+
+import UIKit
+
+enum StatusType {
+    case information
+    case error(StatusErrorable)
+}
+
+class StatusTextFieldView: UIView {
+    
+    // MARK: - Properties -
+    weak var delegate: UITextFieldDelegate? {
+        didSet {
+            textField.delegate = self.delegate
+        }
+    }
+    
+    var type: StatusType {
+        didSet {
+            setupLabels(by: type)
+        }
+    }
+    
+    
+    let exampleText: String?
+    let textFieldPlaceholderText: String?
+    let instructionText: String?
+    // MARK: - Views -
+    lazy var parentStack: UIStackView = .componentStack(elements: [exampleLabel,textField,instructionLabel])
+    
+    lazy var exampleLabel: UILabel = .captionLabel(text: exampleText)
+    lazy var textField: UITextField = .borderedTextField(placeholderText: textFieldPlaceholderText)
+    lazy var instructionLabel: UILabel = .captionLabel(text: instructionText)
+    
+    init(type: StatusType, exampleText: String? = nil, textFieldPlaceholderText: String? = nil, instructionText: String? = nil) {
+        
+        self.exampleText = exampleText
+        self.textFieldPlaceholderText = textFieldPlaceholderText
+        self.instructionText = instructionText
+        self.type = type
+        super.init(frame: .zero)
+        setupLabels(by: type)
+        setupViews()
+    }
+    
+    private func setupLabels(by type: StatusType) {
+        switch type {
+        case .information:
+            exampleLabel.textColor = .label
+            instructionLabel.textColor = .label
+        case .error:
+            exampleLabel.textColor = .systemRed
+            instructionLabel.textColor = .systemRed
+        }
+    }
+    // MARK: - View Lifecycle -
+    private func setupViews() {
+        addSubview(parentStack)
+        constraints()
+    }
+    
+    private func constraints() {
+        parentStack.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            parentStack.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 8),
+            parentStack.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
+            parentStack.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+            parentStack.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor)
+        ])
+    }
+    
+    func displayErrorMessage(for error: StatusErrorable) {
+        self.type = .error(error)
+        exampleLabel.text = error.message
+        instructionLabel.text = error.instructions
+    }
+    
+    func displayStatusMessage() {
+        self.type = .information
+        exampleLabel.text = exampleText
+        instructionLabel.text = instructionText
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("programmatic view")
+    }
+}
+
+class StatusTextField<T: StatusTextFieldDelegate>: UIControl {
+    
+    weak var statusTextFieldDelegate: T? {
+        didSet {
+            textFieldView.delegate = statusTextFieldDelegate
+        }
+    }
+    var type: StatusType
+    var exampleText: String?
+    var textFieldPlaceholderText: String?
+    var instructionText: String?
+    
+    lazy var textFieldView: StatusTextFieldView = StatusTextFieldView(type: type, exampleText: exampleText, textFieldPlaceholderText: textFieldPlaceholderText, instructionText: instructionText)
+    
+    internal init(type: StatusType, exampleText: String? = nil, textFieldPlaceholderText: String? = nil, instructionText: String? = nil) {
+        self.type = type
+        self.exampleText = exampleText
+        self.textFieldPlaceholderText = textFieldPlaceholderText
+        self.instructionText = instructionText
+        super.init(frame: .zero)
+        textFieldView.delegate = statusTextFieldDelegate
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("programmatic view")
+    }
+    
+    private func setupViews() {
+        addSubview(textFieldView)
+        textFieldView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            textFieldView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            textFieldView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
+            textFieldView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+            textFieldView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor)
+        ])
+    }
+    
+    func displayErrorMessage(for error: StatusErrorable) {
+        self.textFieldView.displayErrorMessage(for: error)
+    }
+    
+    func displayStatusMessage() {
+        self.textFieldView.displayStatusMessage()
+    }
+    
+}

--- a/CareForMe/View/Custom Controls/StatusTextField/StatusTextFieldView.swift
+++ b/CareForMe/View/Custom Controls/StatusTextField/StatusTextFieldView.swift
@@ -1,5 +1,5 @@
 //
-//  StatusTextField.swift
+//  StatusTextFieldView.swift
 //  CareForMe
 //
 //  Created by Kenneth Dubroff on 7/20/21.
@@ -90,53 +90,4 @@ class StatusTextFieldView: UIView {
     required init?(coder: NSCoder) {
         fatalError("programmatic view")
     }
-}
-
-class StatusTextField<T: StatusTextFieldDelegate>: UIControl {
-    
-    weak var statusTextFieldDelegate: T? {
-        didSet {
-            textFieldView.delegate = statusTextFieldDelegate
-        }
-    }
-    var type: StatusType
-    var exampleText: String?
-    var textFieldPlaceholderText: String?
-    var instructionText: String?
-    
-    lazy var textFieldView: StatusTextFieldView = StatusTextFieldView(type: type, exampleText: exampleText, textFieldPlaceholderText: textFieldPlaceholderText, instructionText: instructionText)
-    
-    internal init(type: StatusType, exampleText: String? = nil, textFieldPlaceholderText: String? = nil, instructionText: String? = nil) {
-        self.type = type
-        self.exampleText = exampleText
-        self.textFieldPlaceholderText = textFieldPlaceholderText
-        self.instructionText = instructionText
-        super.init(frame: .zero)
-        textFieldView.delegate = statusTextFieldDelegate
-        setupViews()
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("programmatic view")
-    }
-    
-    private func setupViews() {
-        addSubview(textFieldView)
-        textFieldView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            textFieldView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
-            textFieldView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
-            textFieldView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
-            textFieldView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor)
-        ])
-    }
-    
-    func displayErrorMessage(for error: StatusErrorable) {
-        self.textFieldView.displayErrorMessage(for: error)
-    }
-    
-    func displayStatusMessage() {
-        self.textFieldView.displayStatusMessage()
-    }
-    
 }

--- a/CareForMe/View/Extensions/UILabel+title3Label.swift
+++ b/CareForMe/View/Extensions/UILabel+title3Label.swift
@@ -20,6 +20,14 @@ extension UILabel {
         careForMeLabel(text: text, preferred: .subheadline, weight: weight)
     }
     
+    static func captionLabel(text: String?, weight: UIFont.Weight = .semibold) -> UILabel {
+        careForMeLabel(text: text, preferred: .caption1, weight: weight)
+    }
+    
+    static func bodyLabel(text: String?, weight: UIFont.Weight = .regular) -> UILabel {
+        careForMeLabel(text: text, preferred: .body, weight: weight)
+    }
+    
     private static func careForMeLabel(text: String?, preferred font: UIFont.TextStyle, weight: UIFont.Weight) -> UILabel {
         let label = UILabel()
         label.numberOfLines = 0

--- a/CareForMeTests/CareForMeTests.swift
+++ b/CareForMeTests/CareForMeTests.swift
@@ -26,9 +26,9 @@ class CareForMeTests: XCTestCase {
     
     func testStatusTextField_andDelegate_dontRetain() {
         let textField = StatusTextField<Foo>(type: .information, exampleText: "", textFieldPlaceholderText: "", instructionText: "")
-        let foo = Foo(statusTextField: textField)
+        let foo = Foo(textFields: [textField])
         textField.statusTextFieldDelegate = foo
-        
+        XCTAssertNotNil(textField.statusTextFieldDelegate)
         assertNoMemoryLeak(foo)
         assertNoMemoryLeak(textField)
     }

--- a/CareForMeTests/CareForMeTests.swift
+++ b/CareForMeTests/CareForMeTests.swift
@@ -23,6 +23,15 @@ class CareForMeTests: XCTestCase {
         
         assertNoMemoryLeak(alertCategory)
     }
+    
+    func testStatusTextField_andDelegate_dontRetain() {
+        let textField = StatusTextField<Foo>(type: .information, exampleText: "", textFieldPlaceholderText: "", instructionText: "")
+        let foo = Foo(statusTextField: textField)
+        textField.statusTextFieldDelegate = foo
+        
+        assertNoMemoryLeak(foo)
+        assertNoMemoryLeak(textField)
+    }
 
 }
 

--- a/CareForMeTests/CareForMeTests.swift
+++ b/CareForMeTests/CareForMeTests.swift
@@ -11,13 +11,13 @@ import XCTest
 class CareForMeTests: XCTestCase {
 
     func testCategory_andAlert_dontRetain() {
-        let alertCategory = AlertCategory(id: UUID(), color: UIColor.NamedColor.red.rawValue, type: "")
+        let alertCategory = AlertCategory(id: UUID(), color: .init(uiColor: .named(.highlight)), type: "")
         
         let alert = CareAlertType(id: UUID(),
-                              category: alertCategory,
-                              title: "",
-                              message: "",
-                              image: UIImage().pngData() ?? Data())
+                                  category: alertCategory,
+                                  stockPhotoName: .ambulance,
+                                  title: "",
+                                  message: "")
         
         alertCategory.alerts = [alert]
         

--- a/CareForMeTests/CareForMeTests.swift
+++ b/CareForMeTests/CareForMeTests.swift
@@ -25,12 +25,19 @@ class CareForMeTests: XCTestCase {
     }
     
     func testStatusTextField_andDelegate_dontRetain() {
-        let textField = StatusTextField<Foo>(type: .information, exampleText: "", textFieldPlaceholderText: "", instructionText: "")
+        let textField = StatusTextField<Foo>(type: .information)
         let foo = Foo(textFields: [textField])
-        textField.statusTextFieldDelegate = foo
+        
         XCTAssertNotNil(textField.statusTextFieldDelegate)
         assertNoMemoryLeak(foo)
         assertNoMemoryLeak(textField)
+    }
+    
+    func testStatusTextFieldDelegate_NotNil_AfterInit() {
+        let passwordTextField = StatusTextField<PasswordStatusTextFieldDelegate>(type: .information)
+        let delegate = PasswordStatusTextFieldDelegate(textFields: [passwordTextField])
+        XCTAssertEqual(delegate.textFields.count, 1)
+        XCTAssertNotNil(passwordTextField.statusTextFieldDelegate)
     }
 
 }


### PR DESCRIPTION
Created `StatusTextField` and `StatusTextFieldDelegate`

## `StatusTextField<T: StatusTextFieldDelegate>` is a `CustomControl` (could probably be converted to `UIView`)
### Views
- `exampleLabel` currently being used as textField's `title` and error title
- `textField` - `roundedBordered`
- `instructionLabel` provides instructions and error messages
### Internal properties
- `text` - returns `textField`'s text
- `error` - returns error if there is one, nil if not
- `statusTextFieldDelegate: T`

## `StatusErrorable` is a protocol
Used to display error messages in `StatusTextField`s via `StatusTextFieldDelegate`
- `title`
- `message`

## `StatusTextFieldDelegate` is a protocol
Responsible for implementing custom error messages, initializing delegate pattern between `self` and `textFields`, and handling validation
### Requirements:
- must conform to `UITextFieldDelegate` 
`textFields: [StatusTextField<Self>] { get set }`
`textFieldDictionary: [UITextField: StatusTextField<Self>] { get }` used as hashMap for quick lookup in `UITextFieldDelegate` methods
`typealias Error:  StatusErrorable` -  Each Delegate has its own state and should handle errors differently
     - `title`
     - `message`
`init(textFields: [StatusTextField<Self>]`
#### `UITextFieldDelegate` Methods
- `shouldChangeCharactersIn range:`
- `textFieldShouldReturn`

# Quirks:
- `StatusTextFieldDelegate` has generic requirement due to required typealias